### PR TITLE
Fix custom image reader bug

### DIFF
--- a/easydl/dml/infer.py
+++ b/easydl/dml/infer.py
@@ -9,7 +9,9 @@ def images_to_embeddings(images, model: ImageModelWrapper, image_reader=smart_re
     """
     embeddings = []
     for image in images:
-        image = smart_read_image(image)
+        # Use the provided image_reader to load the image. This allows callers
+        # to customize how images are read (e.g. caching or different backends).
+        image = image_reader(image)
         embedding = model(image)
         embeddings.append(embedding)
     return np.array(embeddings)

--- a/tests/dml/test_infer.py
+++ b/tests/dml/test_infer.py
@@ -1,0 +1,19 @@
+import numpy as np
+from easydl.dml.infer import images_to_embeddings
+
+class DummyModel:
+    def __call__(self, image):
+        # return a constant vector for simplicity
+        return np.array([1.0])
+
+def test_images_to_embeddings_custom_reader():
+    called = []
+    def reader(x):
+        called.append(x)
+        return x  # pass through
+    model = DummyModel()
+    images = ['a', 'b', 'c']
+    result = images_to_embeddings(images, model, image_reader=reader)
+    # ensure custom reader was used on each image
+    assert called == images
+    assert result.shape == (3, 1)


### PR DESCRIPTION
## Summary
- fix `images_to_embeddings` to actually use the supplied `image_reader`
- add tests for the helper

## Testing
- `pytest tests/dml/test_infer.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866fa4d5ab4832c82c9f350f1fd61b3