### PR TITLE
Fix typo in Resnet18MetricModel docstring

### DIFF
--- a/easydl/dml/pytorch_models.py
+++ b/easydl/dml/pytorch_models.py
@@ -62,7 +62,7 @@ class EfficientNetMetricModel(nn.Module):
 
 class Resnet18MetricModel(nn.Module):
     """
-    Resnet 18 is easy to trian and test with, thus very good for dry run or development. 
+    Resnet 18 is easy to train and test with, thus very good for dry run or development.
     
     """
     def __init__(self, embedding_dim):


### PR DESCRIPTION
## Summary
- fix small typo in Resnet18MetricModel docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866fbc47e4c832c9310c5d17f97a502