### PR TITLE
chore: update CI Python matrix and add PyTorch CPU wheel index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +47,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        env:
+          PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"


### PR DESCRIPTION
### Motivation
- Reduce CI surface by dropping Python `3.8` from the test matrix to match supported/tested Python versions and avoid dependency compatibility issues. 
- Ensure reliable installs of PyTorch on GitHub runners by pointing `pip` to the official PyTorch CPU wheel index to avoid attempting incompatible GPU/CUDA builds.

### Description
- Updated `.github/workflows/ci.yml` to remove `3.8` from the `matrix.python-version` so the test matrix now runs `3.9`, `3.10`, and `3.11`.
- Added `PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu` to the `Install dependencies` step to prefer PyTorch CPU wheels during `pip` installs.

### Testing
- No automated CI runs were executed for this change since it only modifies the workflow configuration and has not been pushed to trigger the GitHub Actions pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aa2e28940832c9b8e8d145abb72c5)